### PR TITLE
feat: add animal usage statistics for a line (issue #3)

### DIFF
--- a/oscar/historical_stats.py
+++ b/oscar/historical_stats.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 
 import pandas as pd
 
@@ -6,6 +7,105 @@ from oscar.breeding_scheme import (
     BreedingScheme,
     Genotype,
 )
+
+
+# ---------------------------------------------------------------------------
+# Surplus type classification
+# ---------------------------------------------------------------------------
+
+class SurplusType(Enum):
+    """Categories of surplus animals, as defined in issue #3."""
+
+    EXPERIMENTAL = "Experimental"
+    UNAVOIDABLE = "Unavoidable"
+    AVOIDABLE = "Avoidable"
+    OTHER = "Other"
+
+    @classmethod
+    def from_sacrifice_reason(cls, reason: str | None) -> "SurplusType":
+        """Map a raw sacrifice_reason string to a SurplusType.
+
+        Parameters
+        ----------
+        reason : str | None
+            Raw value from the 'sacrifice_reason' column.
+
+        Returns
+        -------
+        SurplusType
+            Matched surplus category, or SurplusType.OTHER if unrecognised.
+        """
+        if reason is None or (isinstance(reason, float)):
+            # NaN / missing → Other
+            return cls.OTHER
+
+        reason_lower = reason.strip().lower()
+
+        # Map known pyRAT sacrifice reasons to surplus categories.
+        # Adjust these mappings to match real pyRAT vocabulary as needed.
+        _EXPERIMENTAL = {
+            "experimental", "experiment", "used for experiment",
+            "killed for experiment", "terminal", "scientific procedure",
+        }
+        _UNAVOIDABLE = {
+            "found dead", "died", "natural death", "spontaneous death",
+            "illness", "sick", "humane endpoint", "welfare",
+            "unexpected death",
+        }
+        _AVOIDABLE = {
+            "surplus", "cull", "culled", "excess", "overproduction",
+            "wrong genotype", "not required",
+        }
+
+        if reason_lower in _EXPERIMENTAL:
+            return cls.EXPERIMENTAL
+        if reason_lower in _UNAVOIDABLE:
+            return cls.UNAVOIDABLE
+        if reason_lower in _AVOIDABLE:
+            return cls.AVOIDABLE
+        return cls.OTHER
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SurplusStatistics:
+    """Counts and proportions for each surplus type."""
+
+    n_per_surplus_type: dict[SurplusType, int] = field(default_factory=dict)
+    proportion_per_surplus_type: dict[SurplusType, float] = field(
+        default_factory=dict
+    )
+    total_n: int = 0
+
+    def _compute_proportions(self) -> None:
+        """Derive proportions from counts. Called after all counts are set."""
+        for surplus_type, n in self.n_per_surplus_type.items():
+            self.proportion_per_surplus_type[surplus_type] = (
+                n / self.total_n if self.total_n > 0 else 0.0
+            )
+
+
+@dataclass
+class LineUsageStatistics:
+    """Animal usage statistics for a single line (issue #3).
+
+    Attributes
+    ----------
+    surplus_per_genotype : dict
+        SurplusStatistics broken down by offspring genotype.
+    overall_surplus : SurplusStatistics
+        Aggregate SurplusStatistics across all offspring genotypes.
+    """
+
+    surplus_per_genotype: dict[tuple[Genotype, ...], SurplusStatistics] = field(
+        default_factory=dict
+    )
+    overall_surplus: SurplusStatistics = field(
+        default_factory=SurplusStatistics
+    )
 
 
 @dataclass
@@ -29,11 +129,17 @@ class LineStatistics:
     total_n_offspring_per_genotype: dict[tuple[Genotype, ...], int] = field(
         default_factory=dict
     )
-
     stats_per_breeding_scheme: dict[
         BreedingScheme, BreedingSchemeStatistics
     ] = field(default_factory=dict)
+    usage_statistics: LineUsageStatistics = field(
+        default_factory=LineUsageStatistics
+    )
 
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def calculate_historical_stats_for_line(
     standardised_data: pd.DataFrame, line_name: str
@@ -51,7 +157,8 @@ def calculate_historical_stats_for_line(
     Returns
     -------
     LineStatistics
-        Summary statistics for the given line
+        Summary statistics for the given line, including usage statistics
+        (surplus breakdown) as required by issue #3.
     """
 
     line_data = standardised_data.loc[
@@ -89,7 +196,83 @@ def calculate_historical_stats_for_line(
                     n_offspring
                 )
 
+    # Issue #3: calculate animal usage (surplus) statistics
+    line_stats.usage_statistics = _calculate_usage_statistics(data_with_schemes)
+
     return line_stats
+
+
+def _calculate_usage_statistics(line_data: pd.DataFrame) -> LineUsageStatistics:
+    """Calculate surplus/usage statistics for a line (issue #3).
+
+    Splits sacrifice_reason into SurplusType categories, then computes
+    counts and percentages both per genotype and overall.
+
+    Parameters
+    ----------
+    line_data : pd.DataFrame
+        Standardised data for a single line, must contain
+        'genotype_offspring' and 'sacrifice_reason' columns.
+
+    Returns
+    -------
+    LineUsageStatistics
+    """
+    usage_stats = LineUsageStatistics()
+
+    # Map each row's sacrifice_reason to a SurplusType
+    surplus_series: pd.Series = line_data["sacrifice_reason"].apply(
+        SurplusType.from_sacrifice_reason
+    )
+
+    # Parse genotype strings once → reuse for grouping
+    genotype_series: pd.Series = line_data["genotype_offspring"].apply(
+        Genotype.from_string
+    )
+
+    # ---- per genotype -------------------------------------------------------
+    for genotype in genotype_series.unique():
+        mask = genotype_series == genotype
+        surplus_for_genotype = surplus_series[mask]
+        usage_stats.surplus_per_genotype[genotype] = _surplus_stats_from_series(
+            surplus_for_genotype
+        )
+
+    # ---- overall (all offspring) --------------------------------------------
+    usage_stats.overall_surplus = _surplus_stats_from_series(surplus_series)
+
+    return usage_stats
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _surplus_stats_from_series(surplus_series: pd.Series) -> SurplusStatistics:
+    """Build a SurplusStatistics from a Series of SurplusType values.
+
+    Parameters
+    ----------
+    surplus_series : pd.Series
+        Each element is a SurplusType.
+
+    Returns
+    -------
+    SurplusStatistics
+        Counts and proportions for every SurplusType.
+    """
+    stats = SurplusStatistics()
+    stats.total_n = len(surplus_series)
+
+    # Initialise all four types to 0 so every key is always present
+    stats.n_per_surplus_type = {st: 0 for st in SurplusType}
+
+    counts = surplus_series.value_counts()
+    for surplus_type, count in counts.items():
+        stats.n_per_surplus_type[surplus_type] = int(count)
+
+    stats._compute_proportions()
+    return stats
 
 
 def _create_breeding_scheme(row: pd.Series) -> BreedingScheme:

--- a/tests/test_usuage_statistics.py
+++ b/tests/test_usuage_statistics.py
@@ -1,0 +1,205 @@
+"""
+Tests for animal usage statistics (issue #3).
+
+Covers:
+  - SurplusType.from_sacrifice_reason mapping
+  - _surplus_stats_from_series counts and proportions
+  - _calculate_usage_statistics per-genotype and overall breakdown
+  - Integration via calculate_historical_stats_for_line
+"""
+
+import pytest
+import pandas as pd
+
+from oscar.historical_stats import (
+    SurplusType,
+    LineUsageStatistics,
+    _surplus_stats_from_series,
+    _calculate_usage_statistics,
+    calculate_historical_stats_for_line,
+)
+from oscar.breeding_scheme import Genotype
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def minimal_line_df():
+    """Minimal standardised dataframe for a single line with two genotypes."""
+    return pd.DataFrame(
+        {
+            "ID_offspring": range(10),
+            "line_name": ["LineA"] * 10,
+            "date_of_birth": ["2024-01-01"] * 5 + ["2024-01-02"] * 5,
+            "ID_father": ["F1"] * 10,
+            "ID_mother": ["M1"] * 10,
+            "genotype_father": ["het"] * 10,
+            "genotype_mother": ["het"] * 10,
+            "genotype_offspring": (
+                ["wt"] * 3 + ["het"] * 5 + ["hom"] * 2
+            ),
+            "sacrifice_reason": (
+                # wt × 3
+                ["surplus", "surplus", "found dead"]
+                # het × 5
+                + ["experimental", "experimental", "surplus", "illness", None]
+                # hom × 2
+                + ["used for experiment", "unknown_reason"]
+            ),
+            "n_mutations": [1] * 10,
+            "mutations": ["GeneX"] * 10,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# SurplusType.from_sacrifice_reason
+# ---------------------------------------------------------------------------
+
+class TestSurplusTypeMapping:
+
+    def test_experimental_reasons(self):
+        for reason in ("experimental", "Experimental", "terminal",
+                       "used for experiment", "scientific procedure"):
+            assert SurplusType.from_sacrifice_reason(reason) == SurplusType.EXPERIMENTAL
+
+    def test_unavoidable_reasons(self):
+        for reason in ("found dead", "died", "illness",
+                       "humane endpoint", "welfare"):
+            assert SurplusType.from_sacrifice_reason(reason) == SurplusType.UNAVOIDABLE
+
+    def test_avoidable_reasons(self):
+        for reason in ("surplus", "cull", "culled",
+                       "excess", "wrong genotype", "not required"):
+            assert SurplusType.from_sacrifice_reason(reason) == SurplusType.AVOIDABLE
+
+    def test_unknown_reason_maps_to_other(self):
+        assert SurplusType.from_sacrifice_reason("unknown_reason") == SurplusType.OTHER
+
+    def test_none_maps_to_other(self):
+        assert SurplusType.from_sacrifice_reason(None) == SurplusType.OTHER
+
+    def test_nan_maps_to_other(self):
+        import math
+        assert SurplusType.from_sacrifice_reason(float("nan")) == SurplusType.OTHER
+
+    def test_case_insensitive(self):
+        assert SurplusType.from_sacrifice_reason("SURPLUS") == SurplusType.AVOIDABLE
+        assert SurplusType.from_sacrifice_reason("  Experimental  ") == SurplusType.EXPERIMENTAL
+
+
+# ---------------------------------------------------------------------------
+# _surplus_stats_from_series
+# ---------------------------------------------------------------------------
+
+class TestSurplusStatsFromSeries:
+
+    def test_all_four_types_always_present(self):
+        series = pd.Series([SurplusType.EXPERIMENTAL])
+        stats = _surplus_stats_from_series(series)
+        assert set(stats.n_per_surplus_type.keys()) == set(SurplusType)
+
+    def test_counts_are_correct(self):
+        series = pd.Series(
+            [SurplusType.EXPERIMENTAL] * 4 +
+            [SurplusType.AVOIDABLE] * 3 +
+            [SurplusType.UNAVOIDABLE] * 2 +
+            [SurplusType.OTHER] * 1
+        )
+        stats = _surplus_stats_from_series(series)
+        assert stats.n_per_surplus_type[SurplusType.EXPERIMENTAL] == 4
+        assert stats.n_per_surplus_type[SurplusType.AVOIDABLE] == 3
+        assert stats.n_per_surplus_type[SurplusType.UNAVOIDABLE] == 2
+        assert stats.n_per_surplus_type[SurplusType.OTHER] == 1
+        assert stats.total_n == 10
+
+    def test_proportions_sum_to_one(self):
+        series = pd.Series(
+            [SurplusType.EXPERIMENTAL] * 6 +
+            [SurplusType.AVOIDABLE] * 4
+        )
+        stats = _surplus_stats_from_series(series)
+        total_pct = sum(stats.proportion_per_surplus_type.values())
+        assert abs(total_pct - 1.0) < 1e-9
+
+    def test_proportion_values_correct(self):
+        series = pd.Series(
+            [SurplusType.EXPERIMENTAL] * 3 +
+            [SurplusType.AVOIDABLE] * 1
+        )
+        stats = _surplus_stats_from_series(series)
+        assert abs(stats.proportion_per_surplus_type[SurplusType.EXPERIMENTAL] - 0.75) < 1e-9
+        assert abs(stats.proportion_per_surplus_type[SurplusType.AVOIDABLE] - 0.25) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# _calculate_usage_statistics
+# ---------------------------------------------------------------------------
+
+class TestCalculateUsageStatistics:
+
+    def test_returns_line_usage_statistics(self, minimal_line_df):
+        result = _calculate_usage_statistics(minimal_line_df)
+        assert isinstance(result, LineUsageStatistics)
+
+    def test_per_genotype_keys_match_offspring_genotypes(self, minimal_line_df):
+        result = _calculate_usage_statistics(minimal_line_df)
+        expected_genotypes = {
+            (Genotype.WT,), (Genotype.HET,), (Genotype.HOM,)
+        }
+        assert set(result.surplus_per_genotype.keys()) == expected_genotypes
+
+    def test_overall_total_equals_all_offspring(self, minimal_line_df):
+        result = _calculate_usage_statistics(minimal_line_df)
+        assert result.overall_surplus.total_n == len(minimal_line_df)
+
+    def test_per_genotype_totals_sum_to_overall(self, minimal_line_df):
+        result = _calculate_usage_statistics(minimal_line_df)
+        genotype_total = sum(
+            s.total_n for s in result.surplus_per_genotype.values()
+        )
+        assert genotype_total == result.overall_surplus.total_n
+
+    def test_wt_surplus_counts(self, minimal_line_df):
+        # wt rows: surplus, surplus, found dead
+        result = _calculate_usage_statistics(minimal_line_df)
+        wt_stats = result.surplus_per_genotype[(Genotype.WT,)]
+        assert wt_stats.n_per_surplus_type[SurplusType.AVOIDABLE] == 2
+        assert wt_stats.n_per_surplus_type[SurplusType.UNAVOIDABLE] == 1
+        assert wt_stats.total_n == 3
+
+    def test_het_surplus_counts(self, minimal_line_df):
+        # het rows: experimental, experimental, surplus, illness, None→OTHER
+        result = _calculate_usage_statistics(minimal_line_df)
+        het_stats = result.surplus_per_genotype[(Genotype.HET,)]
+        assert het_stats.n_per_surplus_type[SurplusType.EXPERIMENTAL] == 2
+        assert het_stats.n_per_surplus_type[SurplusType.AVOIDABLE] == 1
+        assert het_stats.n_per_surplus_type[SurplusType.UNAVOIDABLE] == 1
+        assert het_stats.n_per_surplus_type[SurplusType.OTHER] == 1
+        assert het_stats.total_n == 5
+
+    def test_overall_proportions_sum_to_one(self, minimal_line_df):
+        result = _calculate_usage_statistics(minimal_line_df)
+        total = sum(result.overall_surplus.proportion_per_surplus_type.values())
+        assert abs(total - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Integration: calculate_historical_stats_for_line
+# ---------------------------------------------------------------------------
+
+class TestIntegration:
+
+    def test_usage_statistics_present_in_line_stats(self, minimal_line_df):
+        stats = calculate_historical_stats_for_line(minimal_line_df, "LineA")
+        assert isinstance(stats.usage_statistics, LineUsageStatistics)
+
+    def test_overall_surplus_total_matches_offspring_count(self, minimal_line_df):
+        stats = calculate_historical_stats_for_line(minimal_line_df, "LineA")
+        assert stats.usage_statistics.overall_surplus.total_n == stats.total_n_offspring
+
+    def test_all_surplus_types_present_in_overall(self, minimal_line_df):
+        stats = calculate_historical_stats_for_line(minimal_line_df, "LineA")
+        assert set(stats.usage_statistics.overall_surplus.n_per_surplus_type.keys()) == set(SurplusType)


### PR DESCRIPTION
## Description
**What is this PR**
- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To track how animals from a breeding line are being used — splitting surplus into Experimental, Unavoidable, Avoidable and Other categories, as required by issue #3.

**What does this PR do?**
- Adds `SurplusType` enum that maps `sacrifice_reason` values to one of four categories: Experimental, Unavoidable, Avoidable, Other
- Adds `SurplusStatistics` dataclass storing counts and proportions per surplus type
- Adds `LineUsageStatistics` dataclass with breakdown per genotype and overall across all offspring
- Extends existing `LineStatistics` with a `usage_statistics` field
- Integrates into `calculate_historical_stats_for_line()` with no breaking changes to existing functionality

## References
Closes #3

## How has this PR been tested?
- Added `tests/test_usuage_statistics.py` with full pytest coverage
- Tests cover: SurplusType mapping, counts, proportions, per-genotype breakdown and full integration through `calculate_historical_stats_for_line()`
- All tests pass locally

## Is this a breaking change?
No. All existing fields in `LineStatistics`, `BreedingSchemeStatistics` and related functions are unchanged. `usage_statistics` is a new field added to `LineStatistics`.

## Does this PR require an update to the documentation?
No documentation update required for this PR.

## Checklist:
- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with pre-commit