### PR TITLE
Add developer documentation

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
+        with:
+          use-requirements-txt: false
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# oscar
+# OSCaR
+
+OSCaR (the Open Source Colony-assessment Resource) is a python package for data-driven optimisation of breeding strategies.
+
+## Development setup
+
+First, install the package locally - here we provide instructions for both `uv` and `conda` (use whichever you prefer).
+
+### uv
+
+Install uv following the [instructions on uv's website](https://docs.astral.sh/uv/getting-started/installation/) then run:
+```
+git clone git@github.com:neuroinformatics-unit/OSCaR.git
+cd OSCaR
+uv sync --extra dev
+```
+
+### Conda
+
+Install conda e.g. [via miniforge](https://conda-forge.org/download/) then run:
+
+```
+git clone git@github.com:neuroinformatics-unit/OSCaR.git
+
+conda create -n oscar-dev python=3.12
+conda activate oscar-dev
+pip install -e ".[dev]"
+```
+
+### Pre-commit
+
+We use [pre-commit](https://pre-commit.com/) for automated linting / formatting.
+```
+# setup pre-commit to run on every commit
+pre-commit install
+```
+
+### PyRAT access
+
+#### Token creation
+
+To access a [PyRAT](https://www.scionics.com/pyrat.html) instance via the code in `oscar.colony_management.pyrat`, you will first need to contact Scionics (the creators of PyRAT) to approve access.
+
+- Ask them to setup a new API client called 'OSCaR' on your pyRAT server; they should send you a 'client token'.
+- The new API client will appear under `ADMINISTRATION > API` in pyRAT, and an administrator will need to enable it from there.
+
+This approval process only needs to be done once per pyRAT instance.
+
+Once the client is enabled, any user can request a client token by logging into PyRAT, going to `ADMINISTRATION > API` and clicking the 'Request access' button on the `OSCaR` row.
+
+#### Providing tokens to OSCaR
+
+Once all tokens have been created (as above), they can be provided to OSCaR by setting the following environment variables:
+
+- `PYRAT_URL`: the url of the pyRAT instance you want to access
+- `PYRAT_CLIENT_TOKEN`: the client token sent to you by Scionics
+- `PYRAT_USER_TOKEN`: the user token created via 'Request access' in PyRAT
+
+Set these variables however you prefer - just make sure they are _never_ checked in to version control (tokens should be kept secret). One convenient method is to create a `.env` file at the top level of the repository, then use [`python-dotenv`](https://github.com/theskumar/python-dotenv) to read them.

--- a/README.md
+++ b/README.md
@@ -2,58 +2,6 @@
 
 OSCaR (the Open Source Colony-assessment Resource) is a python package for data-driven optimisation of breeding strategies.
 
-## Development setup
+## Documentation
 
-First, install the package locally - here we provide instructions for both `uv` and `conda` (use whichever you prefer).
-
-### uv
-
-Install uv following the [instructions on uv's website](https://docs.astral.sh/uv/getting-started/installation/) then run:
-```
-git clone git@github.com:neuroinformatics-unit/OSCaR.git
-cd OSCaR
-uv sync --extra dev
-```
-
-### Conda
-
-Install conda e.g. [via miniforge](https://conda-forge.org/download/) then run:
-
-```
-git clone git@github.com:neuroinformatics-unit/OSCaR.git
-
-conda create -n oscar-dev python=3.12
-conda activate oscar-dev
-pip install -e ".[dev]"
-```
-
-### Pre-commit
-
-We use [pre-commit](https://pre-commit.com/) for automated linting / formatting.
-```
-# setup pre-commit to run on every commit
-pre-commit install
-```
-
-### PyRAT access
-
-#### Token creation
-
-To access a [PyRAT](https://www.scionics.com/pyrat.html) instance via the code in `oscar.colony_management.pyrat`, you will first need to contact Scionics (the creators of PyRAT) to approve access.
-
-- Ask them to setup a new API client called 'OSCaR' on your pyRAT server; they should send you a 'client token'.
-- The new API client will appear under `ADMINISTRATION > API` in pyRAT, and an administrator will need to enable it from there.
-
-This approval process only needs to be done once per pyRAT instance.
-
-Once the client is enabled, any user can request a client token by logging into PyRAT, going to `ADMINISTRATION > API` and clicking the 'Request access' button on the `OSCaR` row.
-
-#### Providing tokens to OSCaR
-
-Once all tokens have been created (as above), they can be provided to OSCaR by setting the following environment variables:
-
-- `PYRAT_URL`: the url of the pyRAT instance you want to access
-- `PYRAT_CLIENT_TOKEN`: the client token sent to you by Scionics
-- `PYRAT_USER_TOKEN`: the user token created via 'Request access' in PyRAT
-
-Set these variables however you prefer - just make sure they are _never_ checked in to version control (tokens should be kept secret). One convenient method is to create a `.env` file at the top level of the repository, then use [`python-dotenv`](https://github.com/theskumar/python-dotenv) to read them.
+To setup a development environment, see the [developer docs](docs/source/developer_setup.md).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
--e . # required to build API docs
-linkify-it-py
-myst-parser
-nbsphinx
-pydata-sphinx-theme
-setuptools-scm
-sphinx
-sphinx-autodoc-typehints
-sphinx-sitemap

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,9 +20,9 @@ autodoc_mock_imports = []
 # use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("../.."))
 
-project = "oscar"
-copyright = "2022, Kimberly Meechan"
-author = "Kimberly Meechan"
+project = "OSCaR"
+copyright = "2026, Neuroinformatics Unit"
+author = "Neuroinformatics Unit"
 try:
     full_version = get_version(project)
     # Splitting the release on '+' to remove the commit hash
@@ -88,7 +88,7 @@ exclude_patterns = [
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 html_theme = "pydata_sphinx_theme"
-html_title = "oscar"
+html_title = "OSCaR"
 
 # Customize the theme
 html_theme_options = {
@@ -97,7 +97,7 @@ html_theme_options = {
             # Label for this link
             "name": "GitHub",
             # URL where the link will redirect
-            "url": "provide later",  # required
+            "url": "https://github.com/neuroinformatics-unit/OSCaR",
             # Icon class (if "type": "fontawesome"),
             # or path to local image (if "type": "local")
             "icon": "fa-brands fa-github",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ autodoc_mock_imports = []
 sys.path.insert(0, os.path.abspath("../.."))
 
 project = "OSCaR"
-copyright = "2026, Neuroinformatics Unit"
+copyright = "2026, UCL"
 author = "Neuroinformatics Unit"
 try:
     full_version = get_version(project)

--- a/docs/source/developer_setup.md
+++ b/docs/source/developer_setup.md
@@ -1,0 +1,85 @@
+# Development setup
+
+## Installation
+
+First, install the package locally - here we provide instructions for both `uv` and `conda` (use whichever you prefer).
+
+### uv
+
+Install uv following the [instructions on uv's website](https://docs.astral.sh/uv/getting-started/installation/) then run:
+```
+git clone git@github.com:neuroinformatics-unit/OSCaR.git
+cd OSCaR
+uv sync --extra dev
+```
+
+### Conda
+
+Install conda e.g. [via miniforge](https://conda-forge.org/download/) then run:
+
+```
+git clone git@github.com:neuroinformatics-unit/OSCaR.git
+
+conda create -n oscar-dev python=3.12
+conda activate oscar-dev
+pip install -e ".[dev]"
+```
+
+## Pre-commit
+
+We use [pre-commit](https://pre-commit.com/) for automated linting / formatting.
+```
+# setup pre-commit to run on every commit
+pre-commit install
+```
+
+## PyRAT access
+
+### Token creation
+
+To access a [PyRAT](https://www.scionics.com/pyrat.html) instance via the code in `oscar.colony_management.pyrat`, you will first need to contact Scionics (the creators of PyRAT) to approve access.
+
+- Ask them to setup a new API client called 'OSCaR' on your pyRAT server; they should send you a 'client token'.
+- The new API client will appear under `ADMINISTRATION > API` in pyRAT, and an administrator will need to enable it from there.
+
+This approval process only needs to be done once per pyRAT instance.
+
+Once the client is enabled, any user can request a client token by logging into PyRAT, going to `ADMINISTRATION > API` and clicking the 'Request access' button on the `OSCaR` row.
+
+### Providing tokens to OSCaR
+
+Once all tokens have been created (as above), they can be provided to OSCaR by setting the following environment variables:
+
+- `PYRAT_URL`: the url of the pyRAT instance you want to access
+- `PYRAT_CLIENT_TOKEN`: the client token sent to you by Scionics
+- `PYRAT_USER_TOKEN`: the user token created via 'Request access' in PyRAT
+
+Set these variables however you prefer - just make sure they are _never_ checked in to version control (tokens should be kept secret). One convenient method is to create a `.env` file at the top level of the repository, then use [`python-dotenv`](https://github.com/theskumar/python-dotenv) to read them.
+
+## Building the docs locally
+
+To build the documentation locally, you will need to install some additional dependencies, then run `sphinx-build` (as below).
+
+### docs install with uv
+```
+uv sync --all-extras
+```
+
+### docs install with conda
+```
+conda activate oscar-dev
+pip install -e ".[dev,docs]"
+```
+
+### docs build command
+```
+sphinx-build docs/source docs/build
+```
+Then open the generated `docs/build/index.html` file.
+
+To re-build the documentation after making changes, remove the docs/build
+folder and re-run the above command:
+```
+rm -rf docs/build
+sphinx-build docs/source docs/build
+```

--- a/docs/source/developer_setup.md
+++ b/docs/source/developer_setup.md
@@ -44,7 +44,7 @@ To access a [PyRAT](https://www.scionics.com/pyrat.html) instance via the code i
 
 This approval process only needs to be done once per pyRAT instance.
 
-Once the client is enabled, any user can request a client token by logging into PyRAT, going to `ADMINISTRATION > API` and clicking the 'Request access' button on the `OSCaR` row.
+Once the client is enabled, any user can request a user token by logging into PyRAT, going to `ADMINISTRATION > API` and clicking the 'Request access' button on the `OSCaR` row.
 
 ### Providing tokens to OSCaR
 

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,11 +1,1 @@
 # Getting started
-
-Here you may demonstrate the basic functionalities your package.
-
-You can include code snippets using the usual Markdown syntax:
-
-```python
-from my_package import my_function
-
-result = my_function()
-```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,44 +3,16 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to oscar's documentation!
+Welcome to OSCaR's documentation!
 =========================================================
+
+OSCaR (the Open Source Colony-assessment Resource) is a python package for
+data-driven optimisation of breeding strategies.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    getting_started
+   developer_setup
    api_index
-
-By default the documentation includes the following sections:
-
-* Getting started. Here you could describe the basic functionalities of your package. To modify this page, edit the file ``docs/source/getting_started.md``.
-* API: here you can find the auto-generated documentation of your package, which is based on the docstrings in your code. To modify which modules/classes/functions are included in the API documentation, edit the file ``docs/source/api_index.rst``.
-
-You can create additional sections with narrative documentation,
-by adding new ``.md`` or ``.rst`` files to the ``docs/source`` folder.
-These files should start with a level-1 (H1) header,
-which will be used as the section title. Sub-sections can be created
-with lower-level headers (H2, H3, etc.) within the same file.
-
-To include a section in the rendered documentation,
-add it to the ``toctree`` directive in this (``docs/source/index.rst``) file.
-
-For example, you could create a ``docs/source/installation.md`` file
-and add it to the ``toctree`` like this:
-
-.. code-block:: rst
-
-   .. toctree::
-      :maxdepth: 2
-      :caption: Contents:
-
-      getting_started
-      installation
-      api_index
-
-Index & Search
---------------
-* :ref:`genindex`
-* :ref:`search`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,16 @@ dev = [
   "python-dotenv",
   "responses"
 ]
+docs = [
+    "linkify-it-py",
+    "myst-parser",
+    "nbsphinx",
+    "pydata-sphinx-theme",
+    "setuptools-scm",
+    "sphinx",
+    "sphinx-autodoc-typehints",
+    "sphinx-sitemap"
+]
 
 [build-system]
 requires = [


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
Currently, there are no docs for developer setup

**What does this PR do?**
- Adds documentation about how to setup a development environment for OSCaR
- Removes placeholder text from the docs template
- Moves docs dependencies into `pyproject.toml`, so they're all in one place

I'll add a link to the built github pages site, once I've set that up in the project settings.

## References

Closes https://github.com/neuroinformatics-unit/OSCaR/issues/35

## How has this PR been tested?

N/A - only docs changes

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Docs have been updated.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
