### PR TITLE
Update docs base url

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,8 +114,7 @@ html_theme_options = {
 # Sphinx will create the appropriate CNAME file in the build directory
 # The default is the URL of the GitHub pages
 # https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html
-github_user = "K-Meech"
-html_baseurl = f"https://{github_user}.github.io/{project}"
+html_baseurl = "https://oscar.neuroinformatics.dev"
 sitemap_url_scheme = "{link}"
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**What does this PR do?**

Found the relevant line in the `conf.py` file - continuing from https://github.com/neuroinformatics-unit/OSCaR/pull/36#pullrequestreview-4402421726
Updates the base url to match the new domain.

## References

N/A

## How has this PR been tested?

N/A

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
