### PR TITLE
remove neuroinformatics action upload_pypi

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -62,8 +62,16 @@ jobs:
   upload_all:
     name: Publish build distributions
     needs: [build_sdist_wheels]
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/oscar-colony
+    permissions:
+      id-token: write
     steps:
-    - uses: neuroinformatics-unit/actions/upload_pypi@v2
+    - uses: actions/download-artifact@v8
       with:
-        secret-pypi-key: ${{ secrets.TWINE_API_KEY }}
+        name: artifact
+        path: dist
+    - uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -60,18 +60,16 @@ jobs:
 
 
   upload_all:
-    name: Publish build distributions
-    needs: [build_sdist_wheels]
-    if: github.event_name == 'push' && github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/oscar-colony
-    permissions:
-      id-token: write
-    steps:
-    - uses: actions/download-artifact@v8
-      with:
-        name: artifact
-        path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.14.0
+      name: Publish build distributions
+      needs: [build_sdist_wheels]
+      if: github.event_name == 'push' && github.ref_type == 'tag'
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TWINE_API_KEY }}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**

Uploads to pypi are currently failing. Existing code was using [`neuroinformatics-unit/actions/upload_pypi@v2`](https://github.com/neuroinformatics-unit/actions/tree/main/upload_pypi), which states in its readme that it is incompatible with `PyPI publish GitHub Action > v1.9` (the action is using `pypa/gh-action-pypi-publish@v1.14.0`).

**What does this PR do?**

Removes the `upload_pypi` action and replaces it with suggested code from the [latest version of `gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish#usage). Hopefully this fixes the issue - will try uploading again once merged by making a new release.

## References

For https://github.com/neuroinformatics-unit/OSCaR/issues/46

## How has this PR been tested?

Tests passing

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
